### PR TITLE
add pip installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,12 @@
 
 # 0. Install ansible & passlib, and clone this repo.
 
+If not installed, get pip:
+
+```
+sudo apt-get install python3-pip
+```
+
 Open a terminal & run the following:
 
 ```


### PR DESCRIPTION
simple addition to README to add installation instructions for machines that don't have pip installed.